### PR TITLE
Loadbalancer fix

### DIFF
--- a/infrastructure/ecs-cluster.yaml
+++ b/infrastructure/ecs-cluster.yaml
@@ -28,6 +28,10 @@ Parameters:
   VPC:
     Type: AWS::EC2::VPC::Id
     Description: reference to the vpc the clusters will be deployed to 
+
+  TargetGroup:
+    Type: String
+    Description: reference to the load balancer target group
   
 Mappings:
 
@@ -50,6 +54,8 @@ Resources:
   ECSAutoScalingGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
     Properties:
+      TargetGroupARNs:
+        - !Ref TargetGroup
       VPCZoneIdentifier: !Ref Subnets
       LaunchConfigurationName: !Ref ECSLaunchConfiguration
       MinSize: !Ref ClusterSize

--- a/infrastructure/ecs-cluster.yaml
+++ b/infrastructure/ecs-cluster.yaml
@@ -86,7 +86,7 @@ Resources:
       UserData:
         "Fn::Base64": !Sub |
           #!/bin/bash
-          yum install -y aws-cfn-bootstrap nfs-utils
+          yum install -y aws-cfn-bootstrap
           /opt/aws/bin/cfn-init -v --region ${AWS::Region} --stack ${AWS::StackName} --resource ECSLaunchConfiguration
           /opt/aws/bin/cfn-signal -e $? --region ${AWS::Region} --stack ${AWS::StackName} --resource ECSAutoScalingGroup
 

--- a/infrastructure/load-balancer.yaml
+++ b/infrastructure/load-balancer.yaml
@@ -19,6 +19,10 @@ Parameters:
     Description: security group to apply to the alb
     Type: AWS::EC2::SecurityGroup::Id
 
+  Path:
+    Description: the path to register with the application load balancer
+    Type: String
+
 Resources:
 
   LoadBalancer:
@@ -32,7 +36,7 @@ Resources:
         - Key: Name
           Value: !Ref EnvironmentName
 
-  LoadBalancerListener:
+  Listener:
     Type: AWS::ElasticLoadBalancingV2::Listener
     Properties:
       LoadBalancerArn: !Ref LoadBalancer
@@ -42,6 +46,19 @@ Resources:
         - Type: forward
           TargetGroupArn: !Ref DefaultTargetGroup
 
+  LoadBalancerListener:
+    Type: AWS::ElasticLoadBalancingV2::ListenerRule
+    Properties:
+      ListenerArn: !Ref Listener
+      Priority: 1
+      Conditions:
+        - Field: path-pattern
+          Values:
+            - !Ref Path
+      Actions:
+        - TargetGroupArn: !Ref DefaultTargetGroup
+          Type: forward
+
   DefaultTargetGroup:
     Type: AWS::ElasticLoadBalancingV2::TargetGroup
     Properties:
@@ -49,6 +66,13 @@ Resources:
       VpcId: !Ref VPC
       Port: 80
       Protocol: HTTP
+      Matcher:
+        HttpCode: 200-299
+      HealthCheckIntervalSeconds: 10
+      HealthCheckPath: /
+      HealthCheckProtocol: HTTP
+      HealthCheckTimeoutSeconds: 5
+      HealthyThresholdCount: 2
 
 Outputs:
 
@@ -60,8 +84,12 @@ Outputs:
     Description: the url of the application load balancer
     Value: !GetAtt LoadBalancer.DNSName
 
-  Listener:
+  LoadBalancerListener:
     Description: A reference to a port 80 listener
-    Value: !Ref LoadBalancerListener
+    Value: !Ref Listener
+
+  LoadBalancerTargetGroup:
+    Description: a reference to the defeault load balancer target group
+    Value: !Ref DefaultTargetGroup
 
 

--- a/master.yaml
+++ b/master.yaml
@@ -59,6 +59,7 @@ Resources:
         VPC: !GetAtt VPC.Outputs.VPC
         Subnets: !GetAtt VPC.Outputs.Subnets
         SecurityGroup: !GetAtt SecurityGroups.Outputs.LoadBalancerSecurityGroup
+        Path: /
 
   S3:
     Type: AWS::CloudFormation::Stack
@@ -91,6 +92,7 @@ Resources:
         VPC: !GetAtt VPC.Outputs.VPC
         SecurityGroup: !GetAtt SecurityGroups.Outputs.EC2HostSecurityGroup
         Subnets: !GetAtt VPC.Outputs.Subnets
+        TargetGroup: !GetAtt ALB.Outputs.LoadBalancerTargetGroup
 
   GhostService:
     Type: AWS::CloudFormation::Stack
@@ -100,18 +102,17 @@ Resources:
         VPC: !GetAtt VPC.Outputs.VPC
         Cluster: !GetAtt ECS.Outputs.Cluster
         DesiredCount: 2
-        GhostServiceUrl: !GetAtt ALB.Outputs.LoadBalancerUrl 
-        Path: /
+        GhostServiceUrl: !GetAtt ALB.Outputs.LoadBalancerUrl
         DatabaseUsername: !Ref DatabaseUsername
         DatabasePassword: !Ref DatabasePassword
         DatabaseHostname: !GetAtt DB.Outputs.DatabaseAddress
-        Listener: !GetAtt ALB.Outputs.Listener
         DatabaseName: !Ref DatabaseName
         S3BucketName: !GetAtt S3.Outputs.S3BucketName
         S3Url: !GetAtt S3.Outputs.S3Url
         S3UserName: !GetAtt S3.Outputs.S3UserName
         S3UserAccessKey: !GetAtt S3.Outputs.S3UserAccessKey
         S3UserSecretKey: !GetAtt S3.Outputs.S3UserSecretKey
+        TargetGroup: !GetAtt ALB.Outputs.LoadBalancerTargetGroup
 
 Outputs:
 

--- a/service/ghost.yaml
+++ b/service/ghost.yaml
@@ -15,12 +15,8 @@ Parameters:
     Description: how many instances of this task should we run on the cluster 
     Type: Number
 
-  Listener:
-    Description: the application load balancer to register with
-    Type: String
-
-  Path:
-    Description: the path to register with the application load balancer
+  TargetGroup:
+    Description: reference to the default load balancer target group
     Type: String
 
   DatabaseUsername:
@@ -67,7 +63,6 @@ Resources:
 
   Service:
     Type: AWS::ECS::Service
-    DependsOn: ListenerRule
     Properties:
       Cluster: !Ref Cluster
       Role: !Ref ServiceRole
@@ -126,33 +121,6 @@ Resources:
     Properties:
       LogGroupName: !Ref AWS::StackName
       RetentionInDays: 365
-
-  TargetGroup:
-    Type: AWS::ElasticLoadBalancingV2::TargetGroup
-    Properties:
-      VpcId: !Ref VPC
-      Port: 80
-      Protocol: HTTP
-      Matcher:
-        HttpCode: 200-299
-      HealthCheckIntervalSeconds: 10
-      HealthCheckPath: /
-      HealthCheckProtocol: HTTP
-      HealthCheckTimeoutSeconds: 5
-      HealthyThresholdCount: 2
-
-  ListenerRule:
-    Type: AWS::ElasticLoadBalancingV2::ListenerRule
-    Properties:
-      ListenerArn: !Ref Listener
-      Priority: 1
-      Conditions:
-        - Field: path-pattern
-          Values:
-            - !Ref Path
-      Actions:
-        - TargetGroupArn: !Ref TargetGroup
-          Type: forward
 
   ServiceRole: 
       Type: AWS::IAM::Role


### PR DESCRIPTION
When the service would start, the instances within the ecs cluster were not being enrolled into the default target group for the load balancer. This PR resolves that issue.